### PR TITLE
fix: Remove unnecessary `MAKEFLAGS` breaking build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ $(KERNEL_SOURCES): $(KERNEL_TARBALL)
 	cd $(KERNEL_SOURCES) ; $(MAKE) olddefconfig
 
 $(KERNEL_BINARY_$(GUESTARCH)): $(KERNEL_SOURCES)
-	cd $(KERNEL_SOURCES) ; rm -f .version ; $(MAKE) $(MAKEFLAGS) $(KERNEL_FLAGS)
+	cd $(KERNEL_SOURCES) ; rm -f .version ; $(MAKE) $(KERNEL_FLAGS)
 
 ifeq ($(OS),Darwin)
 $(KERNEL_C_BUNDLE):


### PR DESCRIPTION
Fix build error by removing `$(MAKEFLAGS)` from sub-make invocation

The build was failing with the error:

```
make[3]: *** No rule to make target 'w'.  Stop.
```

This was caused by `$(MAKEFLAGS)` expanding to `w --`, which led `make` to misinterpret `w` as a target.

**Solution:**

Removed `$(MAKEFLAGS)` from the sub-`make` command in the Makefile.

**Changes:**

Before:

```makefile
cd $(KERNEL_SOURCES) ; rm -f .version ; $(MAKE) $(MAKEFLAGS) $(KERNEL_FLAGS)
```

After:

```Makefile
cd $(KERNEL_SOURCES) ; rm -f .version ; $(MAKE) $(KERNEL_FLAGS)
```

This fixes the build error and allows the kernel to compile successfully.
